### PR TITLE
Fix <a> tag lines to have equal spacing between lines

### DIFF
--- a/_sass/base/_reset.scss
+++ b/_sass/base/_reset.scss
@@ -40,6 +40,10 @@ section {
     display: block;
 }
 
+header a {
+  padding: 5px 1px;
+}
+
 h1,
 h2,
 h3,

--- a/_sass/base/_reset.scss
+++ b/_sass/base/_reset.scss
@@ -93,7 +93,7 @@ a {
 
     position: relative;
     display: inline-block;
-    padding: 5px 1px;
+    padding: 0px 1px;
     transition: color ease 0.3s;
     
     /* Hover animation effect for all buttons */


### PR DESCRIPTION
The lines with anchor tag had 5px extra line spacing than lines without links due to padding for anchor tag.