### PR TITLE
Only show separator if both github and twitter usernames are set

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
 <footer class="c-page__footer">
   <p>&copy; {{ site.author }} {{ 'now' | date: '%Y' }}</p>
-  <p>{% if site.twitter_username %}<a href="https://twitter.com/{{ site.twitter_username }}">Twitter</a>{% endif %}{% if site.github_username %}<span class="u-separate"></span><a href="https://github.com/{{ site.github_username }}">Github</a>{% endif %}</p>
+  <p>{% if site.twitter_username %}<a href="https://twitter.com/{{ site.twitter_username }}">Twitter</a>{% if site.github_username %}<span class="u-separate"></span>{% endif %}{% endif %}{% if site.github_username %}<a href="https://github.com/{{ site.github_username }}">Github</a>{% endif %}</p>
 </footer>


### PR DESCRIPTION
Thanks for this awesome theme! It works really well!
However, if one only has a github account and not a twitter a spurious separator is inserted in the footer.
I've fixed this by only inserting the separator if both github_username and twitter_username are set.