### PR TITLE
Fix to use 'jekyll build' to generate correct article links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ disqus_id:
 # Build settings
 include: [_pages]
 markdown: kramdown
-permalink: /:year/:month/:title
+permalink: /:year/:month/:title.html
 
 sass:
     style: compressed


### PR DESCRIPTION
Fixes anchor tag for articles to point to the corresponding html files when using 'jekyll build' to generate static site. Previously using 'jekyll build' pointed links to folder of the article but could not render the article as the link did not have .html extension it needed.
This fix is not needed for people who host their site in github. But is needed for people like me who host our site in bitbucket.
This fix also means to add .html to article link, which works with github too.